### PR TITLE
Add powershell plugin from v0.2 dev

### DIFF
--- a/Payload_Type/athena/agent_code/Athena/Athena.csproj
+++ b/Payload_Type/athena/agent_code/Athena/Athena.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="H.Pipes" Version="2.0.38" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.2" />
     <PackageReference Include="NetCoreServer" Version="6.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/Payload_Type/athena/agent_code/AthenaPlugins/AthenaPlugins.sln
+++ b/Payload_Type/athena/agent_code/AthenaPlugins/AthenaPlugins.sln
@@ -75,7 +75,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sftp", "sftp\sftp.csproj", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ds", "ds\ds.csproj", "{58C8AFC2-AFBC-4A2B-9DFC-CB331D5BA717}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "s3", "s3\s3.csproj", "{9A80ACA0-D97A-4BC7-8E29-67C0BDB91C83}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "s3", "s3\s3.csproj", "{9A80ACA0-D97A-4BC7-8E29-67C0BDB91C83}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "powershell-command", "powershell-command\powershell-command.csproj", "{2CBCCFD0-D5C1-42F8-B327-BD1754E28874}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "powershell-script", "powershell-script\powershell-script.csproj", "{4A1424F3-D875-48C9-9887-89BF08B9F48B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -231,6 +235,14 @@ Global
 		{9A80ACA0-D97A-4BC7-8E29-67C0BDB91C83}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9A80ACA0-D97A-4BC7-8E29-67C0BDB91C83}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9A80ACA0-D97A-4BC7-8E29-67C0BDB91C83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2CBCCFD0-D5C1-42F8-B327-BD1754E28874}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CBCCFD0-D5C1-42F8-B327-BD1754E28874}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CBCCFD0-D5C1-42F8-B327-BD1754E28874}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2CBCCFD0-D5C1-42F8-B327-BD1754E28874}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A1424F3-D875-48C9-9887-89BF08B9F48B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A1424F3-D875-48C9-9887-89BF08B9F48B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A1424F3-D875-48C9-9887-89BF08B9F48B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A1424F3-D875-48C9-9887-89BF08B9F48B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Payload_Type/athena/agent_code/AthenaPlugins/powershell-command/powershell-command.cs
+++ b/Payload_Type/athena/agent_code/AthenaPlugins/powershell-command/powershell-command.cs
@@ -1,0 +1,101 @@
+﻿using System.Management.Automation;
+using System.Text;
+using System.Management.Automation.Runspaces;
+using Microsoft.PowerShell;
+using PluginBase;
+
+namespace Athena
+{
+    public static class Plugin
+    {
+
+        public static ResponseResult Execute(Dictionary<string, object> args)
+        {
+            bool isSuccess = false;
+            string resStr = String.Empty;
+            Runspace runspace;
+
+            if (args.ContainsKey("command") && !string.IsNullOrEmpty((string)args["command"]))
+            {
+                if (Runspace.DefaultRunspace == null)
+                {
+                    InitialSessionState initialSessionState = InitialSessionState.CreateDefault();
+                    initialSessionState.ExecutionPolicy = ExecutionPolicy.Unrestricted;
+
+                    runspace = RunspaceFactory.CreateRunspace(initialSessionState);
+                    runspace.Open();
+                    Runspace.DefaultRunspace = runspace;
+                }
+                else
+                {
+                    runspace = Runspace.DefaultRunspace;
+                }
+
+
+                using (PowerShell ps = PowerShell.Create(runspace))
+                {
+
+                    ps.AddScript((string)args["command"]);
+
+                    try
+                    {
+                        var iAsyncResult = ps.BeginInvoke();
+                        iAsyncResult.AsyncWaitHandle.WaitOne();
+                        var outputCollection = ps.EndInvoke(iAsyncResult);
+                        StringBuilder sb = new StringBuilder();
+
+                        if (outputCollection.Count > 0)
+                        {
+                            foreach (var x in outputCollection)
+                            {
+                                if (x != null)
+                                {
+                                    sb.AppendLine(x.ToString());
+                                }
+                            }
+                            isSuccess = true;
+                            resStr = sb.ToString();
+                        }
+                        else
+                        {
+                            isSuccess = true;
+                            resStr = "no results";
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        //problem running script
+                        isSuccess = false;
+                        resStr = e.Message;
+                    }
+                }
+            }
+            else
+            {
+                isSuccess = false;
+                resStr = "Could not find any parameter";
+            }
+
+            //return response
+            if (!isSuccess)
+            {
+                return new ResponseResult
+                {
+                    completed = "true",
+                    user_output = resStr,
+                    task_id = (string)args["task-id"],
+                    status = "error"
+                };
+            }
+            else
+            {
+                return new ResponseResult
+                {
+                    completed = "true",
+                    user_output = resStr,
+                    task_id = (string)args["task-id"],
+                };
+            }
+        }
+    }
+}

--- a/Payload_Type/athena/agent_code/AthenaPlugins/powershell-command/powershell-command.cs
+++ b/Payload_Type/athena/agent_code/AthenaPlugins/powershell-command/powershell-command.cs
@@ -4,9 +4,9 @@ using System.Management.Automation.Runspaces;
 using Microsoft.PowerShell;
 using PluginBase;
 
-namespace Athena
+namespace Plugin
 {
-    public static class Plugin
+    public static class powershellcommand
     {
 
         public static ResponseResult Execute(Dictionary<string, object> args)

--- a/Payload_Type/athena/agent_code/AthenaPlugins/powershell-command/powershell-command.csproj
+++ b/Payload_Type/athena/agent_code/AthenaPlugins/powershell-command/powershell-command.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>powershell_command</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PluginBase\PluginBase.csproj" />
+  </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="mv $(TargetPath) $(SolutionDir)\bin\" />
+  </Target>
+
+</Project>

--- a/Payload_Type/athena/agent_code/AthenaPlugins/powershell-script/powershell-script.cs
+++ b/Payload_Type/athena/agent_code/AthenaPlugins/powershell-script/powershell-script.cs
@@ -1,0 +1,132 @@
+﻿using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using Microsoft.PowerShell;
+using System.Text;
+using PluginBase;
+
+namespace Athena
+{
+    public static class Plugin
+    {
+        public static ResponseResult Execute(Dictionary<string, object> args)
+        {
+            bool isSuccess = false;
+            string resStr = String.Empty;
+            Runspace runspace;
+
+            if (args.ContainsKey("File"))
+            {
+
+                if (Runspace.DefaultRunspace == null)
+                {
+                    InitialSessionState initialSessionState = InitialSessionState.CreateDefault();
+                    initialSessionState.ExecutionPolicy = ExecutionPolicy.Unrestricted;
+
+                    runspace = RunspaceFactory.CreateRunspace(initialSessionState);
+                    runspace.Open();
+                    Runspace.DefaultRunspace = runspace;
+                }
+                else
+                {
+                    runspace = Runspace.DefaultRunspace;
+                }
+
+
+
+                using (PowerShell ps = PowerShell.Create(runspace))
+                {
+                    if (args.ContainsKey("File") && (string)args["File"] != "")
+                    {
+                        var base64EncodedBytes = Convert.FromBase64String((string)args["ps1"]);
+                        var psStr = Encoding.UTF8.GetString(base64EncodedBytes);
+                        psStr = psStr.Replace("Write-Host", "Write-Output");
+
+                        if (args.ContainsKey("Arguments") && (string)args["Arguments"] != "")
+                        {
+                            ps.AddScript((string)psStr).AddArgument((string)args["psh_file_arg"]);
+                        }
+                        else
+                        {
+                            ps.AddScript((string)psStr);
+                        }
+                    }
+
+                    if (args.ContainsKey("Additional-Command") && (string)args["Additional-Command"] != "")
+                    {
+                        ps.AddScript((string)args["Additional-Command"]);
+                    }
+
+                    try
+                    {
+                        var iAsyncResult = ps.BeginInvoke();
+                        iAsyncResult.AsyncWaitHandle.WaitOne();
+                        var outputCollection = ps.EndInvoke(iAsyncResult);
+                        StringBuilder sb = new StringBuilder();
+
+                        if (outputCollection.Count > 0)
+                        {
+                            foreach (var x in outputCollection)
+                            {
+                                if (x != null)
+                                {
+                                    sb.AppendLine(x.ToString());
+                                }
+                            }
+                            isSuccess = true;
+                            resStr = sb.ToString();
+                        }
+                        else
+                        {
+                            isSuccess = true;
+                            resStr = "no results";
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        //problem running script
+                        isSuccess = false;
+                        resStr = e.Message;
+                    }
+                }
+            }
+            else
+            {
+                isSuccess = false;
+                resStr = "Could not find any parameter";
+            }
+
+
+            //return response
+            if (!isSuccess)
+            {
+                return new ResponseResult
+                {
+                    completed = "true",
+                    user_output = resStr,
+                    task_id = (string)args["task-id"],
+                    status = "error"
+                };
+            }
+            else
+            {
+                return new ResponseResult
+                {
+                    completed = "true",
+                    user_output = resStr,
+                    task_id = (string)args["task-id"],
+                };
+            }
+            /* return new PluginResponse()
+             {
+                 success = isSuccess,
+                 output = resStr
+             };
+         }
+         public class PluginResponse
+         {
+             public bool success { get; set; }
+             public string? output { get; set; }
+         }*/
+        }
+    }
+}

--- a/Payload_Type/athena/agent_code/AthenaPlugins/powershell-script/powershell-script.cs
+++ b/Payload_Type/athena/agent_code/AthenaPlugins/powershell-script/powershell-script.cs
@@ -83,7 +83,6 @@ namespace Plugin
                     }
                     catch (Exception e)
                     {
-                        //problem running script
                         isSuccess = false;
                         resStr = e.Message;
                     }
@@ -116,17 +115,6 @@ namespace Plugin
                     task_id = (string)args["task-id"],
                 };
             }
-            /* return new PluginResponse()
-             {
-                 success = isSuccess,
-                 output = resStr
-             };
-         }
-         public class PluginResponse
-         {
-             public bool success { get; set; }
-             public string? output { get; set; }
-         }*/
         }
     }
 }

--- a/Payload_Type/athena/agent_code/AthenaPlugins/powershell-script/powershell-script.cs
+++ b/Payload_Type/athena/agent_code/AthenaPlugins/powershell-script/powershell-script.cs
@@ -4,9 +4,9 @@ using Microsoft.PowerShell;
 using System.Text;
 using PluginBase;
 
-namespace Athena
+namespace Plugin
 {
-    public static class Plugin
+    public static class powershellscript
     {
         public static ResponseResult Execute(Dictionary<string, object> args)
         {

--- a/Payload_Type/athena/agent_code/AthenaPlugins/powershell-script/powershell-script.csproj
+++ b/Payload_Type/athena/agent_code/AthenaPlugins/powershell-script/powershell-script.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>powershell_script</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PluginBase\PluginBase.csproj" />
+  </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="mv $(TargetPath) $(SolutionDir)\bin\" />
+  </Target>
+
+</Project>

--- a/Payload_Type/athena/mythic/agent_functions/builder.py
+++ b/Payload_Type/athena/mythic/agent_functions/builder.py
@@ -270,7 +270,7 @@ class athena(PayloadType):
                 resp.build_stdout += stdout_err
                 return resp
 
-            command = "dotnet restore; dotnet publish -r {} -c {} --self-contained {} /p:PublishSingleFile={} /p:EnableCompressionInSingleFile={} /p:PublishReadyToRun={} /p:PublishTrimmed={}".format(self.get_parameter("rid"),self.get_parameter("configuration"), self.get_parameter("self-contained"), self.get_parameter("single-file"), self.get_parameter("compressed"),self.get_parameter("ready-to-run"), self.get_parameter("trimmed"))
+            command = "dotnet restore; dotnet publish -r {} -c {} --self-contained {} /p:PublishSingleFile={} /p:EnableCompressionInSingleFile={} /p:PublishReadyToRun={} /p:PublishTrimmed={} /p:IncludeNativeLibrariesForSelfExtract=true".format(self.get_parameter("rid"),self.get_parameter("configuration"), self.get_parameter("self-contained"), self.get_parameter("single-file"), self.get_parameter("compressed"),self.get_parameter("ready-to-run"), self.get_parameter("trimmed"))
             
             
             output_path = "{}/Athena/bin/{}/net6.0/{}/publish/".format(agent_build_path.name,self.get_parameter("configuration").capitalize(), self.get_parameter("rid"))

--- a/Payload_Type/athena/mythic/agent_functions/builder.py
+++ b/Payload_Type/athena/mythic/agent_functions/builder.py
@@ -175,7 +175,7 @@ class athena(PayloadType):
         BuildParameter(
             name="rid",
             parameter_type=BuildParameterType.ChooseOne,
-            choices=["win-x64", "win-x86", "win-arm", "win-arm64", "win7-x64", "win7-x86", "win81-x64", "win81-arm", "win10-x64", "win10-x86", "win10-arm", "win10-arm64",
+            choices=["win10-x64", "win10-x86", "win-arm", "win-arm64", "win7-x64", "win7-x86", "win81-x64", "win81-arm", "win-x64", "win-x86", "win10-arm", "win10-arm64",
             "linux-x64", "linux-musl-x64","linux-arm","linux-arm64","rhel-x64","rhel.6-x64","tizen","tizen.4.0.0","tizen.5.0.0",
             "osx-x64","osx.10.10-x64","osx.10.11-x64","osx.10.12-x64","osx.10.13-x64","osx.10.14-x64","osx.10.15-x64","osx.11.0-x64","osx.11.0-arm64","osx.12-x64","osx.12-arm64"],
             default_value="win-x64",

--- a/Payload_Type/athena/mythic/agent_functions/powershell-command.py
+++ b/Payload_Type/athena/mythic/agent_functions/powershell-command.py
@@ -1,0 +1,51 @@
+from mythic_payloadtype_container.MythicCommandBase import *
+import json
+from mythic_payloadtype_container.MythicRPC import *
+
+
+class PowerShellCommandArguments(TaskArguments):
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line)
+        self.args = [
+            CommandParameter(
+                name="command",
+                type=ParameterType.String,
+                description="Command to be executed",
+                parameter_group_info=[ParameterGroupInfo(ui_position=1, required=False)],
+            ),
+        ]
+    async def parse_arguments(self):
+        if len(self.command_line.strip()) == 0:
+            raise Exception("powershell requires at least one command-line parameter.\n\tUsage: {}".format(PowerShellCommand.help_cmd))
+        if self.command_line[0] == "{":
+            self.load_args_from_json_string(self.command_line)
+        else:
+            self.args["path"].value = self.command_line
+         
+
+
+
+class PowerShellCommandCommand(CommandBase):
+    cmd = "powershell-command"
+    needs_admin = False
+    help_cmd = "powershell-command [command]"
+    description = "Run a powershell command in the agent process`"
+    version = 1
+    is_exit = False
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = False
+    is_upload_file = False
+    is_remove_file = False
+    author = "@ascemama"
+    argument_class = PowerShellCommandArguments
+    attackmapping = ["T1059", "T1059.004"]
+    attributes = CommandAttributes(
+        load_only=True,
+    )
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass

--- a/Payload_Type/athena/mythic/agent_functions/powershell-script.py
+++ b/Payload_Type/athena/mythic/agent_functions/powershell-script.py
@@ -1,0 +1,74 @@
+from mythic_payloadtype_container.MythicCommandBase import *
+import json
+from mythic_payloadtype_container.MythicRPC import *
+
+
+class PowerShellScriptArguments(TaskArguments):
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line)
+        self.args = [
+            CommandParameter(
+                name="Arguments",
+                type=ParameterType.String,
+                description="script argument",
+                parameter_group_info=[ParameterGroupInfo(ui_position=2, required=False)],
+            ),
+            CommandParameter(
+                name="File",
+                type=ParameterType.File,
+                description="or powershell script to be executed",
+                parameter_group_info=[ParameterGroupInfo(ui_position=1,required=True)],
+            ),
+            CommandParameter(
+                name="Additional-Command",
+                type=ParameterType.String,
+                description="Command to be executed after the script",
+                parameter_group_info=[ParameterGroupInfo(ui_position=2, required=False)],
+            )
+        ]
+    async def parse_arguments(self):
+        if len(self.command_line.strip()) == 0:
+            raise Exception("powershell requires at least one command-line parameter.\n\tUsage: {}".format(PowerShellCommand.help_cmd))
+        if self.command_line[0] == "{":
+            self.load_args_from_json_string(self.command_line)
+        else:
+            self.args["path"].value = self.command_line
+         
+
+
+
+class PowerShellScriptCommand(CommandBase):
+    cmd = "powershell-script"
+    needs_admin = False
+    help_cmd = "powershell-script [script] [script_arguments] [additionnal command]"
+    description = "Run a powershell script in the agent process"
+    version = 1
+    is_exit = False
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = True
+    is_upload_file = False
+    is_remove_file = False
+    author = "@ascemama"
+    argument_class = PowerShellScriptArguments
+    attackmapping = ["T1059", "T1059.004"]
+    attributes = CommandAttributes(
+        load_only=True,
+    )
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        if task.args.get_arg("File"):
+            file_resp = await MythicRPC().execute("get_file",file_id=task.args.get_arg("File"),task_id=task.id,get_contents=True)
+            if file_resp.status == MythicRPCStatus.Success:
+                if len(file_resp.response) > 0:
+                    task.args.add_arg("ps1", file_resp.response[0]["contents"])
+                    task.display_params = f"{file_resp.response[0]['filename']}"
+                else:
+                    raise Exception("Failed to find that file")
+            else:
+                raise Exception("Error from Mythic trying to get file: " + str(file_resp.error))
+
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass

--- a/documentation-payload/Athena/commands/powershell-command.md
+++ b/documentation-payload/Athena/commands/powershell-command.md
@@ -1,0 +1,39 @@
++++
+title = "powershell-command"
+chapter = false
+weight = 10
+hidden = false
++++
+
+## Summary
+Execute a powershell command. 
+  
+- Needs Admin: False  
+- Version: 1  
+- Author: @ascemama  
+
+### Arguments
+#### command
+
+- Description: The command to execute
+- Required Value: True  
+- Default Value: None  
+
+
+## Usage
+
+```
+powershell-command [command] [args]
+```
+
+## MITRE ATT&CK Mapping
+
+- T1059  
+## Detailed Summary
+
+Execute a powershell command. Note that :
+ - this plugin works only on windows
+ - some powershell .NET framework commands do not exist in powershell .NET Core
+ - the plugin does not work when payload is built as single file. Due to an open powershell SDK bug : PowerShell/PowerShell#13540
+ - the same powershell runspace is used, meaning variables and function can be reused in later commands.
+  

--- a/documentation-payload/Athena/commands/powershell-command.md
+++ b/documentation-payload/Athena/commands/powershell-command.md
@@ -35,5 +35,6 @@ Execute a powershell command. Note that :
  - this plugin works only on windows
  - some powershell .NET framework commands do not exist in powershell .NET Core
  - the plugin does not work when payload is built as single file. Due to an open powershell SDK bug : PowerShell/PowerShell#13540
+ - the plugin must be built for win10-x64 or win10-x86 target. which should work with windows10/11 and windows server versions. The target win-x86/64 does not work. 
  - the same powershell runspace is used, meaning variables and function can be reused in later commands.
   

--- a/documentation-payload/Athena/commands/powershell-script.md
+++ b/documentation-payload/Athena/commands/powershell-script.md
@@ -44,4 +44,5 @@ Execute a powershell script. Note that :
  - some powershell .NET framework commands do not exist in powershell .NET Core
  - a command can be added which is run after the script
  - the plugin does not work when payload is built as single file. Due to an open powershell SDK bug : PowerShell/PowerShell#13540
+ - the plugin must be built for win10-x64 or win10-x86 target. which should work with windows10/11 and windows server versions. The target win-x86/64 does not work. 
  - the same powershell runspace is used, meaning variables and function can be reused in later commands. 

--- a/documentation-payload/Athena/commands/powershell-script.md
+++ b/documentation-payload/Athena/commands/powershell-script.md
@@ -1,0 +1,47 @@
++++
+title = "powershell-script"
+chapter = false
+weight = 10
+hidden = false
++++
+
+## Summary
+Execute a powershell script.  
+  
+- Needs Admin: False  
+- Version: 1  
+- Author: @ascemama  
+
+### Arguments
+#### command
+
+- Description: The script to execute
+- Required Value: True  
+- Default Value: None  
+#### arguments
+
+- Description: The arguments to pass to the script 
+- Required Value: False  
+- Default Value: None  
+
+- Description: The additionnal command to run after the script 
+- Required Value: False  
+- Default Value: None  
+
+## Usage
+
+```
+powershell-script [script file] [script argument] [additionnal commands]
+```
+
+## MITRE ATT&CK Mapping
+
+- T1059  
+## Detailed Summary
+
+Execute a powershell script. Note that :
+ - this plugin works only on windows
+ - some powershell .NET framework commands do not exist in powershell .NET Core
+ - a command can be added which is run after the script
+ - the plugin does not work when payload is built as single file. Due to an open powershell SDK bug : PowerShell/PowerShell#13540
+ - the same powershell runspace is used, meaning variables and function can be reused in later commands. 


### PR DESCRIPTION
Hi Checkymander,

as you requested I retargeted the powershell plugins so that you can merge to v0.2-dev.

_Note that additionally to not supporting single file build it is important to choose win10-x64 (or win7-x86) for the build. The more general win-x86/64 option does not work. As far as I understand this is another restriction related to the .Net powershell SDK : https://github.com/PowerShell/PowerShell/issues/12522. Anyway I don't think this is a big issue because win10-x64 is the correct RID for win10, win11 and win servers https://docs.microsoft.com/en-us/dotnet/core/rid-catalog_

Let me know if you have any issues with the code.

_BTW, I did not investigate but the "ls" plugin seems broken in this branch_
![LS_plugin_Issue](https://user-images.githubusercontent.com/13386441/177713041-e33a8d05-b801-43e7-a89c-faf4cdfdd63d.png)
