### PR TITLE
Make LF great again(hopefully)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
normalize text in the repo so that the repo actually manages the line endings to be just line feeds by default regardless of the line endings of the editor that makes the changes.(i.e. get rid of the crlf problem and having to run dos2unix)